### PR TITLE
Migrate to Dart 2.12 with null-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0
+
+* Set minimum SDK version to >=2.12.0
+* Migrate to null-safety
+
 ## 1.1.0
 
 * Adds `trimMargin()` method that behaves like Kotlin's trimMargin.

--- a/lib/src/indentation.dart
+++ b/lib/src/indentation.dart
@@ -127,7 +127,7 @@ class Indentation {
   ///
   /// Leaves lines that don't contain [marginPrefix] untouched.
   String trimMargin([String marginPrefix = '|']) {
-    if (_inputIsNullOrBlank()) return _input;
+    if (_inputIsBlank()) return _input;
 
     final lines = LineSplitter.split(_input);
     final buffer = StringBuffer();
@@ -165,7 +165,7 @@ class Indentation {
   // first time in the "find common indentation level" loop, and second time
   // in the loop that applies the indentation.
   Iterable<_Line> _processLines() sync* {
-    if (_inputIsNullOrBlank()) return;
+    if (_inputIsBlank()) return;
 
     for (final line in LineSplitter.split(_input)) {
       final indentationMatch = _whitespace.stringMatch(line);
@@ -178,11 +178,10 @@ class Indentation {
     }
   }
 
-  bool _inputIsNullOrBlank() =>
-      _input == null || _input.isEmpty || _input.trim().isEmpty;
+  bool _inputIsBlank() => _input.isEmpty || _input.trim().isEmpty;
 
   int _findCommonIndentationLevel(Iterable<_Line> lines) {
-    int commonIndentationLevel;
+    int? commonIndentationLevel;
 
     for (final line in lines) {
       // Empty or blank lines do not have indentation.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: indent
 description: Change indentation in multiline Dart strings while preserving the existing relative indentation.
-version: 1.1.0
+version: 2.0.0
 homepage: https://github.com/roughike/indent
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  expected_output: ^1.2.2
+  expected_output: ^2.0.0
   lint: ^1.0.0
   pedantic: ^1.8.0
   test: ^1.6.0

--- a/test/_indent_test.dart
+++ b/test/_indent_test.dart
@@ -20,6 +20,7 @@ void main() {
   _runDataCase('decrease_indentation_by_3', (input) => input.indentBy(-3));
 
   _runDataCase('trim_margin_with_pipe', (input) => input.trimMargin());
+  // ignore: avoid_redundant_argument_values
   _runDataCase('trim_margin_with_pipe', (input) => input.trimMargin('|'));
   _runDataCase('trim_margin_with_hashbang', (input) => input.trimMargin('#!'));
 
@@ -34,8 +35,7 @@ void main() {
     );
   });
 
-  test('null, empty, and blank inputs', () {
-    expect(null.indent(0), '');
+  test('empty and blank inputs', () {
     expect(''.indent(0), equals(''));
     expect('    '.indent(0), equals(''));
   });
@@ -44,14 +44,14 @@ void main() {
 void _runDataCase(
   String filename,
   dynamic Function(String) inputTransformer, [
-  dynamic Function(String) outputTransformer,
+  dynamic Function(String)? outputTransformer,
 ]) {
   for (final dataCase in dataCasesInFile(path: 'test/$filename.unit')) {
     outputTransformer ??= (output) => output;
 
     test(dataCase.description, () {
       final actual = inputTransformer(dataCase.input);
-      final expected = outputTransformer(dataCase.expectedOutput);
+      final expected = outputTransformer!(dataCase.expectedOutput);
       expect(actual, equals(expected));
     });
   }


### PR DESCRIPTION
Changed the minimum SDK to >=2.12.0 and migrated to null-safety.
I've incremented the version number to 2.0.0 as I assume this might cause breaking changes for packages that don't support Dart 2.12.