### PR TITLE
Fixed issue described in https://github.com/roughike/indent/issues/4

### DIFF
--- a/lib/src/indentation.dart
+++ b/lib/src/indentation.dart
@@ -152,7 +152,11 @@ class Indentation {
         }
       }
 
-      buffer.writeln(result);
+      // Checking for buffer to handle "trim first line whitespace" case
+      if (i > 0 && buffer.isNotEmpty) {
+        buffer.writeln();
+      }
+      buffer.write(result);
     }
 
     return buffer.toString();
@@ -204,8 +208,11 @@ class Indentation {
     int desiredIndentationLevel,
   ) {
     final buffer = StringBuffer();
-
+    final lineLastIndex = lines.length - 1;
+    var lineIndex = -1;
     for (final line in lines) {
+      lineIndex += 1;
+
       if (line.content.isEmpty) {
         // Do not indent empty lines.
         buffer.writeln();
@@ -213,23 +220,15 @@ class Indentation {
       }
 
       final diff = line.indentationLevel - currentIndentationLevel;
-      final spaces = _generateIndentation(desiredIndentationLevel + diff);
+      final spaces = _indentation * (desiredIndentationLevel + diff);
 
       buffer
         ..write(spaces)
-        ..writeln(line.content);
-    }
+        ..write(line.content);
 
-    return buffer.toString();
-  }
-
-  // Generates an appropriate amount of spaces for the desired indentation level.
-  String _generateIndentation(int indentationLevel) {
-    if (indentationLevel == 0) return '';
-
-    final buffer = StringBuffer();
-    for (var i = 0; i < indentationLevel; i++) {
-      buffer.write(_indentation);
+      if (lineIndex != lineLastIndex) {
+        buffer.writeln();
+      }
     }
 
     return buffer.toString();

--- a/test/_indent_test.dart
+++ b/test/_indent_test.dart
@@ -1,8 +1,8 @@
 library indent.tests;
 
 import 'package:expected_output/expected_output.dart';
-import 'package:test/test.dart';
 import 'package:indent/indent.dart';
+import 'package:test/test.dart';
 
 void main() {
   _runDataCase(
@@ -35,6 +35,10 @@ void main() {
     );
   });
 
+  test('doesn not add empty newline at the end', () {
+    expect('Hello world'.indentBy(2), equals('  Hello world'));
+  });
+
   test('empty and blank inputs', () {
     expect(''.indent(0), equals(''));
     expect('    '.indent(0), equals(''));
@@ -51,8 +55,17 @@ void _runDataCase(
 
     test(dataCase.description, () {
       final actual = inputTransformer(dataCase.input);
-      final expected = outputTransformer!(dataCase.expectedOutput);
+      final expected = _outputByRemovingLastNewline(
+        outputTransformer!(dataCase.expectedOutput),
+      );
       expect(actual, equals(expected));
     });
   }
+}
+
+dynamic _outputByRemovingLastNewline(dynamic output) {
+  if (output is String && output.endsWith('\n')) {
+    return output.substring(0, output.length - 1);
+  }
+  return output;
 }


### PR DESCRIPTION
There was issues in 2 methods `_indent` and `trimMargin`, that they were adding extra newLine to any input.

So the simple test case didn't work as expected

```dart
  test('doesn not add empty newline at the end', () {
    expect('Hello world'.indentBy(2), equals('  Hello world'));
  });
```

Before the fix, it returned `'  Hello world\n'`

Most of existing test cases were passing before, due to symmetric bug in `expected_output` library - they also added newline to expected output string. To keep them passing I've added workaround to the library output:
```dart
dynamic _outputByRemovingLastNewline(dynamic output) {
  if (output is String && output.endsWith('\n')) {
    return output.substring(0, output.length - 1);
  }
  return output;
}
```

Let me know if you see any issues in my changes.

My only worry is that it can be breaking change for someone, so it's better to increment the version.

BTW The example is quite outdated, I tried to fix it and keep bare-bone web, but it didn't work with the latest Flutter. I guess it's better to rewrite it from scratch with modern Flutter.
  